### PR TITLE
graceful handling of unset settings

### DIFF
--- a/djangocms_multisite/middleware.py
+++ b/djangocms_multisite/middleware.py
@@ -9,20 +9,29 @@ from django.utils.six.moves import urllib_parse as urlparse
 
 class CMSMultiSiteMiddleware(object):
     def process_request(self, request):
+        MULTISITE_CMS_URLS = getattr(settings, 'MULTISITE_CMS_URLS', {})
+        MULTISITE_CMS_ALIASES = getattr(settings, 'MULTISITE_CMS_ALIASES', {})
+        MULTISITE_CMS_FALLBACK = getattr(settings, 'MULTISITE_CMS_FALLBACK', '')
         try:
             parsed = urlparse.urlparse(request.build_absolute_uri())
             host = parsed.hostname.split(':')[0]
             urlconf = None
             try:
-                urlconf = settings.MULTISITE_CMS_URLS[host]
+                urlconf = MULTISITE_CMS_URLS[host]
             except KeyError:
-                for domain, hosts in settings.MULTISITE_CMS_ALIASES.items():
-                    if host in hosts:
-                        urlconf = settings.MULTISITE_CMS_URLS[domain]
+                for domain, hosts in MULTISITE_CMS_ALIASES.items():
+                    if host in hosts and domain in MULTISITE_CMS_URLS:
+                        urlconf = MULTISITE_CMS_URLS[domain]
                         break
-            if not urlconf:
-                urlconf = settings.MULTISITE_CMS_URLS[settings.MULTISITE_CMS_FALLBACK]
-            request.urlconf = urlconf
+            if (
+                not urlconf and
+                MULTISITE_CMS_FALLBACK and
+                MULTISITE_CMS_FALLBACK in MULTISITE_CMS_URLS.keys()
+            ):
+                urlconf = MULTISITE_CMS_URLS[MULTISITE_CMS_FALLBACK]
+
+            if urlconf:
+                request.urlconf = urlconf
             # sets urlconf for current thread, so that code that does not know
             # about the request (e.g MyModel.get_absolute_url()) get the correct
             # urlconf.

--- a/djangocms_multisite/middleware.py
+++ b/djangocms_multisite/middleware.py
@@ -41,8 +41,7 @@ class CMSMultiSiteMiddleware(object):
             set_urlconf(None)
 
     def process_response(self, request, response):
-        if getattr(request, 'urlconf', None):
-            patch_vary_headers(response, ('Host',))
+        patch_vary_headers(response, ('Host',))
         # set back to default urlconf
         set_urlconf(None)
         return response


### PR DESCRIPTION
Use blank defaults for `MULTISITE_CMS_URLS`, `MULTISITE_CMS_ALIASES` and
`MULTISITE_CMS_FALLBACK` to minimise required configuration

Also: Always `patch_vary_headers` on `Host`
