### PR TITLE
Force reload at each request

### DIFF
--- a/djangocms_multisite/middleware.py
+++ b/djangocms_multisite/middleware.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+from cms.utils.apphook_reload import reload_urlconf
 from django.conf import settings
 from django.core.urlresolvers import set_urlconf
 from django.utils.cache import patch_vary_headers
@@ -36,6 +37,11 @@ class CMSMultiSiteMiddleware(object):
             # about the request (e.g MyModel.get_absolute_url()) get the correct
             # urlconf.
             set_urlconf(urlconf)
+            try:
+                # In django CMS 3.4.2 this allows us to sae a few queries thanks to per-site appresolvers caching
+                reload_urlconf(clear_cache=False)
+            except TypeError:
+                reload_urlconf()
         except KeyError:
             # use default urlconf (settings.ROOT_URLCONF)
             set_urlconf(None)

--- a/djangocms_multisite/middleware.py
+++ b/djangocms_multisite/middleware.py
@@ -38,7 +38,7 @@ class CMSMultiSiteMiddleware(object):
             # urlconf.
             set_urlconf(urlconf)
             try:
-                # In django CMS 3.4.2 this allows us to sae a few queries thanks to per-site appresolvers caching
+                # In django CMS 3.4.2 this allows us to save a few queries thanks to per-site appresolvers caching
                 reload_urlconf(clear_cache=False)
             except TypeError:
                 reload_urlconf()


### PR DESCRIPTION
After the urlconf setup, we force django CMS to reload it all, this force reload apphooks for the current site.
in 3.4.1 and below this will cause a performance hit due to apphooks to be rescanned. It's fixed in 3.4.2 thanks to apphook in memory caching