### PR TITLE
Bringing support for (tests against at least) django 2.2 and 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.venv
 
 # Complexity
 output/*.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ language: python
 sudo: false
 
 python:
+  - 3.7
   - 3.6
-  - 3.5
-  - 2.7
 
 env:
   matrix:
@@ -16,13 +15,14 @@ env:
   # - TOXENV='docs' docs currently not included
   - DJANGO='django111' CMS='cms35'
   - DJANGO='django111' CMS='cms34'
+  - DJANGO='django22' CMS='cms35'
+  - DJANGO='django22' CMS='cms34'
 
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export PYVER=py27; fi"
-  - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PYVER=py35; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PYVER=py36; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then export PYVER=py37; fi"
   - "if [[ ${DJANGO}z != 'z' ]]; then export TOXENV=$PYVER-$DJANGO-$CMS; fi"
 
 # command to run tests, e.g. python setup.py test
@@ -36,17 +36,11 @@ after_success:
 
 matrix:
   exclude:
-  - python: 2.7
+  - python: 3.7
     env: TOXENV='docs'
-  - python: 2.7
+  - python: 3.7
     env: TOXENV='pep8'
-  - python: 2.7
-    env: TOXENV='isort'
-  - python: 3.5
-    env: TOXENV='docs'
-  - python: 3.5
-    env: TOXENV='pep8'
-  - python: 3.5
+  - python: 3.7
     env: TOXENV='isort'
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
   - DJANGO='django111' CMS='cms34'
   - DJANGO='django22' CMS='cms35'
   - DJANGO='django22' CMS='cms34'
+  - DJANGO='django3' CMS='cms35'
+  - DJANGO='django3' CMS='cms34'
 
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ Support
 Supported *Django* versions:
 
 * Django 1.11
+* Django 2.2
 
 Supported django CMS versions:
 

--- a/djangocms_multisite/middleware.py
+++ b/djangocms_multisite/middleware.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
+from urllib.parse import urlparse
 
 from cms.utils.apphook_reload import reload_urlconf
 from django.conf import settings
 from django.urls import set_urlconf
 from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
-from urllib.parse import urlparse
 
 
 class CMSMultiSiteMiddleware(MiddlewareMixin):

--- a/djangocms_multisite/middleware.py
+++ b/djangocms_multisite/middleware.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.utils.apphook_reload import reload_urlconf
 from django.conf import settings
-from django.core.urlresolvers import set_urlconf
+from django.urls import set_urlconf
 from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.six.moves import urllib_parse as urlparse
+from urllib.parse import urlparse
 
 
 class CMSMultiSiteMiddleware(MiddlewareMixin):
@@ -15,7 +15,7 @@ class CMSMultiSiteMiddleware(MiddlewareMixin):
         MULTISITE_CMS_ALIASES = getattr(settings, 'MULTISITE_CMS_ALIASES', {})
         MULTISITE_CMS_FALLBACK = getattr(settings, 'MULTISITE_CMS_FALLBACK', '')
         try:
-            parsed = urlparse.urlparse(request.build_absolute_uri())
+            parsed = urlparse(request.build_absolute_uri())
             host = parsed.hostname.split(':')[0]
             urlconf = None
             try:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Natural Language :: English',
         'Framework :: Django',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.2',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals

--- a/tests/test_utils/urls1.py
+++ b/tests/test_utils/urls1.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.utils.conf import get_cms_setting
 from django.conf import settings
@@ -29,6 +28,6 @@ except ImportError:
 urlpatterns += staticfiles_urlpatterns()
 
 urlpatterns += i18n_patterns(
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^', include('cms.urls')),
 )

--- a/tests/test_utils/urls1.py
+++ b/tests/test_utils/urls1.py
@@ -7,7 +7,7 @@ from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.views.i18n import javascript_catalog
+from django.views.i18n import JavaScriptCatalog
 from django.views.static import serve
 
 admin.autodiscover()
@@ -17,7 +17,7 @@ urlpatterns = [
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
     url(r'^media/cms/(?P<path>.*)$', serve,
         {'document_root': get_cms_setting('MEDIA_ROOT'), 'show_indexes': True}),
-    url(r'^jsi18n/(?P<packages>\S+?)/$', javascript_catalog),
+    url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
 ]
 
 try:

--- a/tests/test_utils/urls2.py
+++ b/tests/test_utils/urls2.py
@@ -7,7 +7,7 @@ from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.views.i18n import javascript_catalog
+from django.views.i18n import JavaScriptCatalog
 from django.views.static import serve
 
 admin.autodiscover()
@@ -17,7 +17,7 @@ urlpatterns = [
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
     url(r'^media/cms/(?P<path>.*)$', serve,
         {'document_root': get_cms_setting('MEDIA_ROOT'), 'show_indexes': True}),
-    url(r'^jsi18n/(?P<packages>\S+?)/$', javascript_catalog),
+    url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
 ]
 
 try:

--- a/tests/test_utils/urls2.py
+++ b/tests/test_utils/urls2.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.utils.conf import get_cms_setting
 from django.conf import settings
@@ -29,6 +28,6 @@ except ImportError:
 urlpatterns += staticfiles_urlpatterns()
 
 urlpatterns += i18n_patterns(
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^subpath/', include('cms.urls')),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,isort,py{37,36,35,27}-django{111}-cms{35,34}
+envlist = pep8,isort,py{37,36}-django{111,22}-cms{35,34}
 
 [testenv]
 commands = {env:COMMAND:python} cms_helper.py test djangocms_multisite
@@ -25,7 +25,7 @@ skip_install = true
 
 [testenv:pep8]
 deps = flake8
-commands = flake8
+commands = flake8 djangocms_multisite
 skip_install = true
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,10 @@ envlist = pep8,isort,py{37,36,35,27}-django{111}-cms{35,34}
 [testenv]
 commands = {env:COMMAND:python} cms_helper.py test djangocms_multisite
 deps =
+    django3: Django>=3.0,<3.1
+    django3: django-mptt>=0.9
+    django22: Django>=2.2,<2.3
+    django22: django-mptt>=0.9
     django111: Django>=1.11,<2.0
     django111: django-mptt>=0.9
     cms34: https://github.com/divio/django-cms/archive/release/3.4.x.zip

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,isort,py{37,36}-django{111,22}-cms{35,34}
+envlist = pep8,isort,py{37,36}-django{111,22,3}-cms{35,34}
 
 [testenv]
 commands = {env:COMMAND:python} cms_helper.py test djangocms_multisite


### PR DESCRIPTION
Taking the changes in #27 and adding a little extra because it didn't fix issues in the tests and was still maintaining python 2.7.

This drops python 2.7, 3.5 and brings in python 3.7 and django 2.2 and 3.0